### PR TITLE
feat(github-repository): manage CODEOWNERS via IaC

### DIFF
--- a/modules/github-repository/main.tf
+++ b/modules/github-repository/main.tf
@@ -25,10 +25,26 @@ resource "github_branch_default" "default" {
 }
 
 locals {
-  variables = var.enabled ? var.variables : {}
+  variables  = var.enabled ? var.variables : {}
   #   secrets   = var.enabled ? { for k, v in nonsensitive(var.secrets) : k => sensitive(v) } : {} // Migrate to Vault Secrets
-  labels   = var.enabled ? var.labels : {}
-  rulesets = var.enabled ? var.rulesets : {}
+  labels     = var.enabled ? var.labels : {}
+  rulesets   = var.enabled ? var.rulesets : {}
+  codeowners = var.enabled ? var.codeowners : []
+}
+
+resource "github_repository_file" "codeowners" {
+  count      = length(local.codeowners) > 0 ? 1 : 0
+  repository = join("", github_repository.default[*].name)
+  branch     = var.default_branch
+  file       = ".github/CODEOWNERS"
+  content    = join("\n", local.codeowners)
+
+  commit_message      = "chore: update CODEOWNERS [skip ci]"
+  commit_author       = "github-actions[bot]"
+  commit_email        = "github-actions[bot]@users.noreply.github.com"
+  overwrite_on_create = true
+
+  depends_on = [github_branch_default.default]
 }
 
 resource "github_actions_variable" "default" {

--- a/modules/github-repository/variables.tf
+++ b/modules/github-repository/variables.tf
@@ -121,6 +121,12 @@ variable "labels" {
   nullable = false
 }
 
+variable "codeowners" {
+  description = "Lines for the .github/CODEOWNERS file. Each string is one pattern-to-owners entry. Last matching pattern wins (GitHub semantics)."
+  type        = list(string)
+  default     = []
+}
+
 variable "rulesets" {
   description = "A map of rulesets to configure for the repository"
   type = map(object({

--- a/units/github-repository/terragrunt.hcl
+++ b/units/github-repository/terragrunt.hcl
@@ -17,9 +17,9 @@ locals {
   # Callers can override a ruleset by using the same key, or add new ones with a different key.
   default_rulesets = {
     default_branch_protection = {
-      name        = "default-branch-protection"
-      target      = "branch"
-      enforcement = "active"
+      name          = "default-branch-protection"
+      target        = "branch"
+      enforcement   = "active"
       bypass_actors = []
       conditions = {
         ref_name = {
@@ -32,7 +32,7 @@ locals {
         non_fast_forward = true
         pull_request = {
           dismiss_stale_reviews_on_push     = true
-          require_code_owner_review         = false
+          require_code_owner_review         = true
           require_last_push_approval        = false
           required_approving_review_count   = 1
           required_review_thread_resolution = false
@@ -41,13 +41,21 @@ locals {
     }
   }
 
+  # Org-standard CODEOWNERS baseline: CI/CD paths always require platform review,
+  # regardless of who owns the rest of the repo.
+  # Stack entries are appended after this baseline (last-match-wins in GitHub).
+  default_codeowners = [
+    "/.github/ @proxmox-home-lab/platform",
+  ]
+
   caller_values = try(values, {})
 
   merged = merge(
     local.defaults,
     local.caller_values,
     {
-      rulesets = merge(local.default_rulesets, try(local.caller_values.rulesets, {}))
+      rulesets   = merge(local.default_rulesets, try(local.caller_values.rulesets, {}))
+      codeowners = concat(local.default_codeowners, try(local.caller_values.codeowners, []))
     }
   )
 }


### PR DESCRIPTION
## Summary
- Add `codeowners` variable to the `github-repository` module — accepts a list of CODEOWNERS lines (order preserved)
- Push `.github/CODEOWNERS` to each managed repo via `github_repository_file` on every apply
- Unit default baseline: `/.github/ @proxmox-home-lab/platform` (CI/CD paths always protected)
- Stack entries append per-repo patterns; last-match-wins (GitHub semantics)
- Enable `require_code_owner_review = true` in the default branch protection ruleset

## Test plan
- [ ] `tofu validate` on `modules/github-repository/`
- [ ] Plan shows `github_repository_file.codeowners` to be created for each repo
- [ ] Apply creates `.github/CODEOWNERS` in each managed repo with correct content
- [ ] Branch protection ruleset updated: `require_code_owner_review = true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)