### PR TITLE
feat(github-repository): add import_id support and .github name validation

### DIFF
--- a/modules/github-repository/variables.tf
+++ b/modules/github-repository/variables.tf
@@ -9,8 +9,8 @@ variable "name" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9][a-zA-Z0-9-]{0,38}$", var.name))
-    error_message = "Repository name must be alphanumeric and can contain hyphens, but cannot start or end with a hyphen and must be between 1 and 39 characters long."
+    condition     = can(regex("^(\\.github|[a-zA-Z0-9][a-zA-Z0-9-]{0,38})$", var.name))
+    error_message = "Repository name must be alphanumeric with optional hyphens (1-39 chars), or the special org repo name '.github'."
   }
 }
 

--- a/units/github-repository/terragrunt.hcl
+++ b/units/github-repository/terragrunt.hcl
@@ -50,14 +50,32 @@ locals {
 
   caller_values = try(values, {})
 
+  # import_id is a Terragrunt-only field used to generate an OpenTofu import block
+  # for repos that already exist in GitHub. Stripped before passing inputs to Terraform.
+  import_id = try(local.caller_values.import_id, "")
+
   merged = merge(
     local.defaults,
-    local.caller_values,
+    { for k, v in local.caller_values : k => v if k != "import_id" },
     {
       rulesets   = merge(local.default_rulesets, try(local.caller_values.rulesets, {}))
       codeowners = concat(local.default_codeowners, try(local.caller_values.codeowners, []))
     }
   )
+}
+
+# Generates an OpenTofu import block when import_id is provided.
+# Needed for repos that already exist in GitHub and must be brought into IaC state.
+# Safe to leave permanently: OpenTofu ignores the block if the resource is already in state.
+generate "imports" {
+  path      = "imports.tf"
+  if_exists = "overwrite"
+  contents  = local.import_id != "" ? <<-EOF
+    import {
+      to = github_repository.default[0]
+      id = "${local.import_id}"
+    }
+  EOF : ""
 }
 
 terraform {


### PR DESCRIPTION
## Summary

- Allow `.github` as a valid repository name (special GitHub org repo)
- Add `import_id` mechanism: Terragrunt-only field in unit `values` that generates
  an OpenTofu `import {}` block for repos already existing in GitHub
- `import_id` is stripped before being passed as inputs to the Terraform module
- Safe to leave permanently: OpenTofu ignores import blocks for resources already in state

## Test plan

- [ ] PR plan shows no unexpected changes on existing repos
- [ ] `.github` repo is correctly imported into state on first apply
- [ ] CODEOWNERS file is created in repos that define `codeowners`

🤖 Generated with [Claude Code](https://claude.com/claude-code)