### PR TITLE
feat(github-repository): grant teams repo access via IaC

### DIFF
--- a/modules/github-repository/main.tf
+++ b/modules/github-repository/main.tf
@@ -25,7 +25,8 @@ resource "github_branch_default" "default" {
 }
 
 locals {
-  variables  = var.enabled ? var.variables : {}
+  team_access = var.enabled ? var.team_access : {}
+  variables   = var.enabled ? var.variables : {}
   #   secrets   = var.enabled ? { for k, v in nonsensitive(var.secrets) : k => sensitive(v) } : {} // Migrate to Vault Secrets
   labels     = var.enabled ? var.labels : {}
   rulesets   = var.enabled ? var.rulesets : {}
@@ -45,6 +46,13 @@ resource "github_repository_file" "codeowners" {
   overwrite_on_create = true
 
   depends_on = [github_branch_default.default]
+}
+
+resource "github_team_repository" "access" {
+  for_each   = local.team_access
+  team_id    = each.key
+  repository = join("", github_repository.default[*].name)
+  permission = each.value
 }
 
 resource "github_actions_variable" "default" {

--- a/modules/github-repository/variables.tf
+++ b/modules/github-repository/variables.tf
@@ -85,6 +85,18 @@ variable "has_wiki" {
   default     = false
 }
 
+variable "team_access" {
+  description = "Map of GitHub team slugs to their permission level (pull, triage, push, maintain, admin). Teams must have at least push to be valid CODEOWNERS."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+
+  validation {
+    condition     = alltrue([for _, v in var.team_access : contains(["pull", "triage", "push", "maintain", "admin"], v)])
+    error_message = "Permission must be one of: pull, triage, push, maintain, admin."
+  }
+}
+
 variable "variables" {
   description = "Environment variables for the repository"
   type        = map(string)

--- a/units/github-repository/terragrunt.hcl
+++ b/units/github-repository/terragrunt.hcl
@@ -65,12 +65,19 @@ locals {
   # for repos that already exist in GitHub. Stripped before passing inputs to Terraform.
   import_id = try(local.caller_values.import_id, "")
 
+  # Org-standard team access: platform team always gets push so CODEOWNERS entries work.
+  # Callers can add more teams; platform entry is merged last so it cannot be downgraded.
+  default_team_access = {
+    platform = "push"
+  }
+
   merged = merge(
     local.defaults,
     { for k, v in local.caller_values : k => v if k != "import_id" },
     {
-      rulesets   = merge(local.default_rulesets, try(local.caller_values.rulesets, {}))
-      codeowners = concat(local.default_codeowners, try(local.caller_values.codeowners, []))
+      rulesets    = merge(local.default_rulesets, try(local.caller_values.rulesets, {}))
+      codeowners  = concat(local.default_codeowners, try(local.caller_values.codeowners, []))
+      team_access = merge(try(local.caller_values.team_access, {}), local.default_team_access)
     }
   )
 }


### PR DESCRIPTION
## Summary

- Adds `team_access` variable (map of team slug → permission level) to the `github-repository` module
- Adds `github_team_repository` resource that grants each team the specified permission
- The unit wrapper injects `platform = "push"` as a default, ensuring `@proxmox-home-lab/platform` always has write access

## Why

CODEOWNERS entries referencing `@proxmox-home-lab/platform` produce a validation error unless the team has explicit write access to the repository:

> *Unknown owner: make sure the team @proxmox-home-lab/platform exists, is publicly visible, and has write access to the repository*

This change fixes that error for all repos that use the `github-repository` unit.

## Behaviour

- Callers can pass additional teams via `team_access`; the `platform = "push"` default is merged last so it cannot be downgraded by a caller value
- Setting `enabled = false` skips team access grants alongside all other resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)